### PR TITLE
:sparkle: Utilities to deal with `fields`

### DIFF
--- a/changes/20221222175115.feature
+++ b/changes/20221222175115.feature
@@ -1,0 +1,1 @@
+:sparkle: Utilities to deal with fields

--- a/utils/field/fields.go
+++ b/utils/field/fields.go
@@ -2,6 +2,7 @@
  * Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package field
 
 import "time"

--- a/utils/field/fields.go
+++ b/utils/field/fields.go
@@ -1,0 +1,148 @@
+package field
+
+import "time"
+
+// ToOptionalInt returns a pointer to an int
+func ToOptionalInt(i int) *int {
+	return &i
+}
+
+// OptionalInt returns the value of an optional field or else
+// returns defaultValue.
+func OptionalInt(ptr *int, defaultValue int) int {
+	if ptr != nil {
+		return *ptr
+	}
+	return defaultValue
+}
+
+// ToOptionalInt32 returns a pointer to an int32.
+func ToOptionalInt32(i int32) *int32 {
+	return &i
+}
+
+// OptionalInt32 returns the value of an optional field or else
+// returns defaultValue.
+func OptionalInt32(ptr *int32, defaultValue int32) int32 {
+	if ptr != nil {
+		return *ptr
+	}
+	return defaultValue
+}
+
+// ToOptionalUint returns a pointer to an uint
+func ToOptionalUint(i uint) *uint {
+	return &i
+}
+
+// OptionalUint returns the value of an optional field or else returns defaultValue.
+func OptionalUint(ptr *uint, defaultValue uint) uint {
+	if ptr != nil {
+		return *ptr
+	}
+	return defaultValue
+}
+
+// ToOptionalUint32 returns a pointer to an uint32.
+func ToOptionalUint32(i uint32) *uint32 {
+	return &i
+}
+
+// OptionalUint32 returns the value of an optional field or else returns defaultValue.
+func OptionalUint32(ptr *uint32, defaultValue uint32) uint32 {
+	if ptr != nil {
+		return *ptr
+	}
+	return defaultValue
+}
+
+// ToOptionalInt64 returns a pointer to an int64.
+func ToOptionalInt64(i int64) *int64 {
+	return &i
+}
+
+// OptionalInt64 returns the value of an optional field or else returns defaultValue.
+func OptionalInt64(ptr *int64, defaultValue int64) int64 {
+	if ptr != nil {
+		return *ptr
+	}
+	return defaultValue
+}
+
+// ToOptionalUint64 returns a pointer to an uint64.
+func ToOptionalUint64(i uint64) *uint64 {
+	return &i
+}
+
+// OptionalUint64 returns the value of an optional field or else returns defaultValue.
+func OptionalUint64(ptr *uint64, defaultValue uint64) uint64 {
+	if ptr != nil {
+		return *ptr
+	}
+	return defaultValue
+}
+
+// ToOptionalBool returns a pointer to a bool.
+func ToOptionalBool(b bool) *bool {
+	return &b
+}
+
+// OptionalBool returns the value of an optional field or else returns defaultValue.
+func OptionalBool(ptr *bool, defaultValue bool) bool {
+	if ptr != nil {
+		return *ptr
+	}
+	return defaultValue
+}
+
+// ToOptionalString returns a pointer to a string.
+func ToOptionalString(s string) *string {
+	return &s
+}
+
+// OptionalString returns the value of an optional field or else returns defaultValue.
+func OptionalString(ptr *string, defaultValue string) string {
+	if ptr != nil {
+		return *ptr
+	}
+	return defaultValue
+}
+
+// ToOptionalFloat32 returns a pointer to a float32.
+func ToOptionalFloat32(i float32) *float32 {
+	return &i
+}
+
+// OptionalFloat32 returns the value of an optional field or else returns defaultValue.
+func OptionalFloat32(ptr *float32, defaultValue float32) float32 {
+	if ptr != nil {
+		return *ptr
+	}
+	return defaultValue
+}
+
+// ToOptionalFloat64 returns a pointer to a float64.
+func ToOptionalFloat64(i float64) *float64 {
+	return &i
+}
+
+// OptionalFloat64 returns the value of an optional field or else returns defaultValue.
+func OptionalFloat64(ptr *float64, defaultValue float64) float64 {
+	if ptr != nil {
+		return *ptr
+	}
+	return defaultValue
+}
+
+// ToOptionalDuration returns a pointer to a Duration.
+func ToOptionalDuration(i time.Duration) *time.Duration {
+	return &i
+}
+
+// OptionalDuration returns the value of an optional field or else returns defaultValue.
+func OptionalDuration(ptr *time.Duration, defaultValue time.Duration) time.Duration {
+	if ptr != nil {
+		return *ptr
+	}
+	return defaultValue
+}

--- a/utils/field/fields.go
+++ b/utils/field/fields.go
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package field
 
 import "time"

--- a/utils/field/fields_test.go
+++ b/utils/field/fields_test.go
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package field
 
 import (

--- a/utils/field/fields_test.go
+++ b/utils/field/fields_test.go
@@ -1,0 +1,194 @@
+package field
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionalField(t *testing.T) {
+	tests := []struct {
+		fieldType    string
+		value        any
+		defaultValue any
+		setFunction  func(any) any
+		getFunction  func(any, any) any
+	}{
+		{
+			fieldType:    "Int",
+			value:        time.Now().Second(),
+			defaultValue: 76,
+			setFunction: func(a any) any {
+				return ToOptionalInt(a.(int))
+			},
+			getFunction: func(a any, a2 any) any {
+				var ptr *int
+				if a != nil {
+					ptr = a.(*int)
+				}
+				return OptionalInt(ptr, a2.(int))
+			},
+		},
+		{
+			fieldType:    "UInt",
+			value:        uint(time.Now().Second()),
+			defaultValue: uint(76),
+			setFunction: func(a any) any {
+				return ToOptionalUint(a.(uint))
+			},
+			getFunction: func(a any, a2 any) any {
+				var ptr *uint
+				if a != nil {
+					ptr = a.(*uint)
+				}
+				return OptionalUint(ptr, a2.(uint))
+			},
+		},
+		{
+			fieldType:    "Int32",
+			value:        int32(time.Now().Second()),
+			defaultValue: int32(97894),
+			setFunction: func(a any) any {
+				return ToOptionalInt32(a.(int32))
+			},
+			getFunction: func(a any, a2 any) any {
+				var ptr *int32
+				if a != nil {
+					ptr = a.(*int32)
+				}
+				return OptionalInt32(ptr, a2.(int32))
+			},
+		},
+		{
+			fieldType:    "UInt32",
+			value:        uint32(time.Now().Second()),
+			defaultValue: uint32(97894),
+			setFunction: func(a any) any {
+				return ToOptionalUint32(a.(uint32))
+			},
+			getFunction: func(a any, a2 any) any {
+				var ptr *uint32
+				if a != nil {
+					ptr = a.(*uint32)
+				}
+				return OptionalUint32(ptr, a2.(uint32))
+			},
+		},
+		{
+			fieldType:    "Int64",
+			value:        time.Now().Unix(),
+			defaultValue: int64(97894),
+			setFunction: func(a any) any {
+				return ToOptionalInt64(a.(int64))
+			},
+			getFunction: func(a any, a2 any) any {
+				var ptr *int64
+				if a != nil {
+					ptr = a.(*int64)
+				}
+				return OptionalInt64(ptr, a2.(int64))
+			},
+		},
+		{
+			fieldType:    "UInt64",
+			value:        uint64(time.Now().Unix()),
+			defaultValue: uint64(97894),
+			setFunction: func(a any) any {
+				return ToOptionalUint64(a.(uint64))
+			},
+			getFunction: func(a any, a2 any) any {
+				var ptr *uint64
+				if a != nil {
+					ptr = a.(*uint64)
+				}
+				return OptionalUint64(ptr, a2.(uint64))
+			},
+		},
+		{
+			fieldType:    "Float32",
+			value:        float32(time.Now().Second()),
+			defaultValue: float32(97894.1545),
+			setFunction: func(a any) any {
+				return ToOptionalFloat32(a.(float32))
+			},
+			getFunction: func(a any, a2 any) any {
+				var ptr *float32
+				if a != nil {
+					ptr = a.(*float32)
+				}
+				return OptionalFloat32(ptr, a2.(float32))
+			},
+		},
+		{
+			fieldType:    "Float64",
+			value:        float64(time.Now().Second()),
+			defaultValue: float64(97894.1545),
+			setFunction: func(a any) any {
+				return ToOptionalFloat64(a.(float64))
+			},
+			getFunction: func(a any, a2 any) any {
+				var ptr *float64
+				if a != nil {
+					ptr = a.(*float64)
+				}
+				return OptionalFloat64(ptr, a2.(float64))
+			},
+		},
+		{
+			fieldType:    "Bool",
+			value:        false,
+			defaultValue: true,
+			setFunction: func(a any) any {
+				return ToOptionalBool(a.(bool))
+			},
+			getFunction: func(a any, a2 any) any {
+				var ptr *bool
+				if a != nil {
+					ptr = a.(*bool)
+				}
+				return OptionalBool(ptr, a2.(bool))
+			},
+		},
+		{
+			fieldType:    "String",
+			value:        faker.Sentence(),
+			defaultValue: faker.Name(),
+			setFunction: func(a any) any {
+				return ToOptionalString(a.(string))
+			},
+			getFunction: func(a any, a2 any) any {
+				var ptr *string
+				if a != nil {
+					ptr = a.(*string)
+				}
+				return OptionalString(ptr, a2.(string))
+			},
+		},
+		{
+			fieldType:    "Duration",
+			value:        time.Millisecond,
+			defaultValue: time.Second,
+			setFunction: func(a any) any {
+				return ToOptionalDuration(a.(time.Duration))
+			},
+			getFunction: func(a any, a2 any) any {
+				var ptr *time.Duration
+				if a != nil {
+					ptr = a.(*time.Duration)
+				}
+				return OptionalDuration(ptr, a2.(time.Duration))
+			},
+		},
+	}
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.fieldType, func(t *testing.T) {
+			to := test.setFunction(test.value)
+			assert.NotNil(t, to)
+			assert.Equal(t, test.defaultValue, test.getFunction(nil, test.defaultValue))
+			assert.Equal(t, test.value, test.getFunction(to, test.defaultValue))
+		})
+	}
+}


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Proprietary
-->
### Description

Utilities to deal with `fields`


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
