### PR TITLE
:sparkle: `[links]` Added a facility for serialising links

### DIFF
--- a/changes/20230421142554.feature
+++ b/changes/20230421142554.feature
@@ -1,0 +1,1 @@
+:sparkle: `[links]` Added a facility for serialising links

--- a/utils/links/link.go
+++ b/utils/links/link.go
@@ -1,6 +1,14 @@
+/*
+ * Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Package links provides utilities to deal with links
 package links
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 // SerialiseLink serialises links into JSON strings
 func SerialiseLink(links any) (str string) {
@@ -12,5 +20,8 @@ func SerialiseLink(links any) (str string) {
 		return
 	}
 	str = string(linkStr)
+	if str == "\"\"" {
+		str = ""
+	}
 	return
 }

--- a/utils/links/link.go
+++ b/utils/links/link.go
@@ -1,0 +1,16 @@
+package links
+
+import "encoding/json"
+
+// SerialiseLink serialises links into JSON strings
+func SerialiseLink(links any) (str string) {
+	if links == nil {
+		return
+	}
+	linkStr, err := json.Marshal(links)
+	if err != nil {
+		return
+	}
+	str = string(linkStr)
+	return
+}

--- a/utils/links/link_test.go
+++ b/utils/links/link_test.go
@@ -1,0 +1,17 @@
+package links
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ARM-software/embedded-development-services-client-utils/utils/links/linkstest"
+)
+
+func TestSerialiseLink(t *testing.T) {
+	link, err := linkstest.NewFakeLink()
+	require.NoError(t, err)
+	assert.NotEmpty(t, SerialiseLink(link))
+
+}

--- a/utils/links/link_test.go
+++ b/utils/links/link_test.go
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2020-2023 Arm Limited or its affiliates and Contributors. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package links
 
 import (
@@ -10,8 +15,11 @@ import (
 )
 
 func TestSerialiseLink(t *testing.T) {
+	assert.Empty(t, SerialiseLink(nil))
+	assert.Empty(t, SerialiseLink(""))
 	link, err := linkstest.NewFakeLink()
 	require.NoError(t, err)
 	assert.NotEmpty(t, SerialiseLink(link))
+	assert.NotEmpty(t, SerialiseLink(&link))
 
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Proprietary
-->
### Description

- Added a facility for serialising links


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
