### PR TITLE
:bug: Make sure that the logger logs every message instead of exiting before it prints anything due to a lack of 'next page'

### DIFF
--- a/changes/20240508104451.bugfix
+++ b/changes/20240508104451.bugfix
@@ -1,0 +1,1 @@
+:bug: Make sure that the logger logs every message instead of exiting before it prints anything due to a lack of 'next page'


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Proprietary
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

This is a stop gap until we fix the underlying problem

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
