### PR TITLE
:bug: [`job`] Wait for job to start before progressing with messages

### DIFF
--- a/changes/20240617160218.bugfix
+++ b/changes/20240617160218.bugfix
@@ -1,0 +1,1 @@
+:bug: [`job`] Wait for job to start before progressing with messages

--- a/utils/go.mod
+++ b/utils/go.mod
@@ -3,8 +3,8 @@ module github.com/ARM-software/embedded-development-services-client-utils/utils
 go 1.22
 
 require (
-	github.com/ARM-software/embedded-development-services-client/client v1.31.3
-	github.com/ARM-software/golang-utils/utils v1.66.1
+	github.com/ARM-software/embedded-development-services-client/client v1.31.4
+	github.com/ARM-software/golang-utils/utils v1.68.0
 	github.com/go-faker/faker/v4 v4.4.2
 	github.com/go-logr/logr v1.4.2
 	github.com/golang/mock v1.6.0

--- a/utils/go.sum
+++ b/utils/go.sum
@@ -1,8 +1,8 @@
 bitbucket.org/creachadair/stringset v0.0.9/go.mod h1:t+4WcQ4+PXTa8aQdNKe40ZP6iwesoMFWAxPGd3UGjyY=
-github.com/ARM-software/embedded-development-services-client/client v1.31.3 h1:OJTaRUnmfdVBZWaY6ALg3FQ0SRlbASM4bHmL97yxvsU=
-github.com/ARM-software/embedded-development-services-client/client v1.31.3/go.mod h1:DfoiGBGolbmt6mud6JG0fCEd2UpMyFaeYsB9d7cVSNo=
-github.com/ARM-software/golang-utils/utils v1.66.1 h1:fuaJ6uB5hbKXHVeaitZK5KeDCIryN0WAgkwnbbxUX70=
-github.com/ARM-software/golang-utils/utils v1.66.1/go.mod h1:PFxtFy3iRiGvmH6X9EUflQet+VcuUS3WZ0qD/rtTu2A=
+github.com/ARM-software/embedded-development-services-client/client v1.31.4 h1:sUtf53bEPaME7GBqPAFCBoVRDdAn6brZAuVnlYfsKns=
+github.com/ARM-software/embedded-development-services-client/client v1.31.4/go.mod h1:ZNNMwjBLtXKIUHed1p3EYy71CzFWeUv8C/HLgqlNvY0=
+github.com/ARM-software/golang-utils/utils v1.68.0 h1:Sp92FvRhGhzfnvIKHDdLb8slrhcidBNFzB9GkpcsN3E=
+github.com/ARM-software/golang-utils/utils v1.68.0/go.mod h1:pjIYW6jPUXH7/kxkZEPyzRwiux+NUG/BFJFn8zaJ/0A=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=

--- a/utils/job/interfaces.go
+++ b/utils/job/interfaces.go
@@ -29,13 +29,16 @@ type IAsynchronousJob interface {
 	GetSuccess() bool
 	// GetStatus returns the state the job is in. This is for information only and should not be relied upon as likely to change. Use flags for implementing a state machine.
 	GetStatus() string
+	// GetQueued returns whether the job is being queued and has not started just yet
+	GetQueued() bool
 }
 
 // IJobManager defines a manager of asynchronous jobs
 type IJobManager interface {
 	// HasJobCompleted calls the services to determine whether the job has completed.
 	HasJobCompleted(ctx context.Context, job IAsynchronousJob) (completed bool, err error)
-
+	// HasJobStarted calls the services to determine whether the job has started.
+	HasJobStarted(ctx context.Context, job IAsynchronousJob) (completed bool, err error)
 	// WaitForJobCompletion waits for a job to complete.
 	WaitForJobCompletion(ctx context.Context, job IAsynchronousJob) (err error)
 }

--- a/utils/job/jobtest/testing.go
+++ b/utils/job/jobtest/testing.go
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package job
+package jobtest
 
 import (
 	"github.com/go-faker/faker/v4"
@@ -16,6 +16,10 @@ type MockAsynchronousJob struct {
 	resource.IResource
 	done    bool
 	failure bool
+}
+
+func (m *MockAsynchronousJob) GetQueued() bool {
+	return !m.done
 }
 
 func (m *MockAsynchronousJob) FetchType() string {
@@ -42,7 +46,7 @@ func (m *MockAsynchronousJob) GetStatus() string {
 	return faker.Word()
 }
 
-func newMockAsynchronousJob(done bool, failure bool) (IAsynchronousJob, error) {
+func newMockAsynchronousJob(done bool, failure bool) (*MockAsynchronousJob, error) {
 	r, err := resourcetests.NewMockResource()
 	if err != nil {
 		return nil, err
@@ -54,14 +58,18 @@ func newMockAsynchronousJob(done bool, failure bool) (IAsynchronousJob, error) {
 	}, nil
 }
 
-func NewMockUndoneAsynchronousJob() (IAsynchronousJob, error) {
+func NewMockUndoneAsynchronousJob() (*MockAsynchronousJob, error) {
 	return newMockAsynchronousJob(false, false)
 }
 
-func NewMockSuccessfulAsynchronousJob() (IAsynchronousJob, error) {
+func NewMockQueuedAsynchronousJob() (*MockAsynchronousJob, error) {
+	return newMockAsynchronousJob(false, false)
+}
+
+func NewMockSuccessfulAsynchronousJob() (*MockAsynchronousJob, error) {
 	return newMockAsynchronousJob(true, false)
 }
 
-func NewMockFailedAsynchronousJob() (IAsynchronousJob, error) {
+func NewMockFailedAsynchronousJob() (*MockAsynchronousJob, error) {
 	return newMockAsynchronousJob(true, true)
 }

--- a/utils/mocks/mock_job.go
+++ b/utils/mocks/mock_job.go
@@ -142,6 +142,20 @@ func (mr *MockIAsynchronousJobMockRecorder) GetFailure() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFailure", reflect.TypeOf((*MockIAsynchronousJob)(nil).GetFailure))
 }
 
+// GetQueued mocks base method.
+func (m *MockIAsynchronousJob) GetQueued() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetQueued")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// GetQueued indicates an expected call of GetQueued.
+func (mr *MockIAsynchronousJobMockRecorder) GetQueued() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueued", reflect.TypeOf((*MockIAsynchronousJob)(nil).GetQueued))
+}
+
 // GetStatus mocks base method.
 func (m *MockIAsynchronousJob) GetStatus() string {
 	m.ctrl.T.Helper()
@@ -206,6 +220,21 @@ func (m *MockIJobManager) HasJobCompleted(arg0 context.Context, arg1 job.IAsynch
 func (mr *MockIJobManagerMockRecorder) HasJobCompleted(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasJobCompleted", reflect.TypeOf((*MockIJobManager)(nil).HasJobCompleted), arg0, arg1)
+}
+
+// HasJobStarted mocks base method.
+func (m *MockIJobManager) HasJobStarted(arg0 context.Context, arg1 job.IAsynchronousJob) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasJobStarted", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasJobStarted indicates an expected call of HasJobStarted.
+func (mr *MockIJobManagerMockRecorder) HasJobStarted(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasJobStarted", reflect.TypeOf((*MockIJobManager)(nil).HasJobStarted), arg0, arg1)
 }
 
 // WaitForJobCompletion mocks base method.


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Proprietary
-->
### Description

- the job manager was not handling the fact a job could be queued for some time and so, no messages would be accessible.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
