### PR TITLE
:sparkles: Add the possibility to set a timeout for waiting job completion

### DIFF
--- a/changes/20240619155022.feature
+++ b/changes/20240619155022.feature
@@ -1,0 +1,1 @@
+:sparkles: Add the possibility to set a timeout for waiting job completion

--- a/utils/job/interfaces.go
+++ b/utils/job/interfaces.go
@@ -8,6 +8,7 @@ package job
 
 import (
 	"context"
+	"time"
 
 	"github.com/ARM-software/embedded-development-services-client-utils/utils/resource"
 )
@@ -43,6 +44,8 @@ type IJobManager interface {
 	HasJobCompleted(ctx context.Context, job IAsynchronousJob) (completed bool, err error)
 	// HasJobStarted calls the services to determine whether the job has started.
 	HasJobStarted(ctx context.Context, job IAsynchronousJob) (completed bool, err error)
-	// WaitForJobCompletion waits for a job to complete.
+	// WaitForJobCompletion waits for a job to complete. Similar to WaitForJobCompletionWithTimeout but with a timeout set to 5 minutes.
 	WaitForJobCompletion(ctx context.Context, job IAsynchronousJob) (err error)
+	// WaitForJobCompletionWithTimeout waits for a job to complete but with timeout protection.
+	WaitForJobCompletionWithTimeout(ctx context.Context, job IAsynchronousJob, timeout time.Duration) (err error)
 }

--- a/utils/mocks/mock_job.go
+++ b/utils/mocks/mock_job.go
@@ -12,6 +12,7 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 
@@ -277,4 +278,18 @@ func (m *MockIJobManager) WaitForJobCompletion(arg0 context.Context, arg1 job.IA
 func (mr *MockIJobManagerMockRecorder) WaitForJobCompletion(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForJobCompletion", reflect.TypeOf((*MockIJobManager)(nil).WaitForJobCompletion), arg0, arg1)
+}
+
+// WaitForJobCompletionWithTimeout mocks base method.
+func (m *MockIJobManager) WaitForJobCompletionWithTimeout(arg0 context.Context, arg1 job.IAsynchronousJob, arg2 time.Duration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForJobCompletionWithTimeout", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForJobCompletionWithTimeout indicates an expected call of WaitForJobCompletionWithTimeout.
+func (mr *MockIJobManagerMockRecorder) WaitForJobCompletionWithTimeout(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForJobCompletionWithTimeout", reflect.TypeOf((*MockIJobManager)(nil).WaitForJobCompletionWithTimeout), arg0, arg1, arg2)
 }


### PR DESCRIPTION

<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Proprietary
-->
### Description

- add a timeout entry and determine retries based on this value


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
