### PR TITLE
:sparkles: Remove explicit type dependency from artefacts utils

### DIFF
--- a/changes/20250404125454.feature
+++ b/changes/20250404125454.feature
@@ -1,0 +1,1 @@
+:sparkles: Remove explicit type dependency from artefacts utils

--- a/utils/artefacts/artefacts.go
+++ b/utils/artefacts/artefacts.go
@@ -28,16 +28,16 @@ const relativePathKey = "Relative Path"
 
 type (
 	// GetArtefactManagersFirstPageFunc defines the function which can retrieve the first page of artefact managers.
-	GetArtefactManagersFirstPageFunc[D LinkData, L Links[D], C Collection[D, L]] = func(ctx context.Context, job string) (C, *http.Response, error)
+	GetArtefactManagersFirstPageFunc[D ILinkData, L ILinks[D], C ICollection[D, L]] = func(ctx context.Context, job string) (C, *http.Response, error)
 	// FollowLinkToArtefactManagersPageFunc is a function able to follow a link to an artefact manager page.
-	FollowLinkToArtefactManagersPageFunc[D LinkData, L Links[D], C Collection[D, L]] = func(ctx context.Context, link D) (C, *http.Response, error)
+	FollowLinkToArtefactManagersPageFunc[D ILinkData, L ILinks[D], C ICollection[D, L]] = func(ctx context.Context, link D) (C, *http.Response, error)
 	// GetArtefactManagerFunc is a function which retrieves information about an artefact manager.
-	GetArtefactManagerFunc[M Manager] = func(ctx context.Context, job, artefact string) (M, *http.Response, error)
+	GetArtefactManagerFunc[M IManager] = func(ctx context.Context, job, artefact string) (M, *http.Response, error)
 	// GetArtefactContentFunc is a function able to return the content of any artefact managers.
 	GetArtefactContentFunc = func(ctx context.Context, job, artefactID string) (*os.File, *http.Response, error)
 )
 
-func determineArtefactDestination[M Manager](outputDir string, maintainTree bool, item M) (artefactFileName string, destinationDir string, err error) {
+func determineArtefactDestination[M IManager](outputDir string, maintainTree bool, item M) (artefactFileName string, destinationDir string, err error) {
 	if any(item) == nil {
 		err = fmt.Errorf("%w: missing artefact item", commonerrors.ErrUndefined)
 		return
@@ -76,10 +76,10 @@ func determineArtefactDestination[M Manager](outputDir string, maintainTree bool
 }
 
 type ArtefactManager[
-	M Manager,
-	D LinkData,
-	L Links[D],
-	C Collection[D, L],
+	M IManager,
+	D ILinkData,
+	L ILinks[D],
+	C ICollection[D, L],
 ] struct {
 	getArtefactManagerFunc            GetArtefactManagerFunc[M]
 	getArtefactContentFunc            GetArtefactContentFunc
@@ -89,10 +89,10 @@ type ArtefactManager[
 
 // NewArtefactManager returns an artefact manager.
 func NewArtefactManager[
-	M Manager,
-	D LinkData,
-	L Links[D],
-	C Collection[D, L],
+	M IManager,
+	D ILinkData,
+	L ILinks[D],
+	C ICollection[D, L],
 ](
 	getArtefactManagersFirstPage GetArtefactManagersFirstPageFunc[D, L, C],
 	getArtefactsManagersPage FollowLinkToArtefactManagersPageFunc[D, L, C],

--- a/utils/artefacts/artefacts_test.go
+++ b/utils/artefacts/artefacts_test.go
@@ -156,12 +156,12 @@ func (t *testArtefact) testGetOutputArtefact(ctx context.Context, _, artefact st
 	return nil, &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(safeio.NewByteReader(ctx, []byte("hello")))}, commonerrors.ErrNotFound
 }
 
-func newTestArtefactManager(t *testing.T, tmpDir, artefactContent string, linksOnly bool) (IArtefactManager, *testArtefact) {
+func newTestArtefactManager(t *testing.T, tmpDir, artefactContent string, linksOnly bool) (IArtefactManager[*client.ArtefactManagerItem, *client.HalLinkData], *testArtefact) {
 	testArtefact := newTestArtefact(t, tmpDir, artefactContent, !linksOnly)
 	return NewArtefactManager(testArtefact.testGetArtefactManagers, nil, testArtefact.testGetArtefactManager, testArtefact.testGetOutputArtefact), testArtefact
 }
 
-func newTestArtefactManagerWithEmbeddedResources(t *testing.T, tmpDir, artefactContent string) (IArtefactManager, *testArtefact) {
+func newTestArtefactManagerWithEmbeddedResources(t *testing.T, tmpDir, artefactContent string) (IArtefactManager[*client.ArtefactManagerItem, *client.HalLinkData], *testArtefact) {
 	return newTestArtefactManager(t, tmpDir, artefactContent, false)
 }
 

--- a/utils/artefacts/interface.go
+++ b/utils/artefacts/interface.go
@@ -8,23 +8,25 @@ package artefacts
 import (
 	"context"
 
-	"github.com/ARM-software/embedded-development-services-client/client"
 	"github.com/ARM-software/golang-utils/utils/collection/pagination"
 )
 
 //go:generate mockgen -destination=../mocks/mock_$GOPACKAGE.go -package=mocks github.com/ARM-software/embedded-development-services-client-utils/utils/$GOPACKAGE IArtefactManager
 
-type IArtefactManager interface {
+type IArtefactManager[
+	M Manager,
+	D LinkData,
+] interface {
 	// DownloadJobArtefactFromLink downloads a specific artefact into the output directory from a particular link. The artefact will be placed at the root of the output directory.
-	DownloadJobArtefactFromLink(ctx context.Context, jobName string, outputDirectory string, artefactManagerItemLink *client.HalLinkData) error
+	DownloadJobArtefactFromLink(ctx context.Context, jobName string, outputDirectory string, artefactManagerItemLink D) error
 	// DownloadJobArtefactFromLinkWithTree downloads a specific artefact into the output directory from a particular link.
 	// maintainTreeLocation specifies whether the artefact will be placed in a tree structure or if it will be flat.
-	DownloadJobArtefactFromLinkWithTree(ctx context.Context, jobName string, maintainTreeLocation bool, outputDirectory string, artefactManagerItemLink *client.HalLinkData) error
+	DownloadJobArtefactFromLinkWithTree(ctx context.Context, jobName string, maintainTreeLocation bool, outputDirectory string, artefactManagerItemLink D) error
 	// DownloadJobArtefact downloads a specific artefact into the output directory. The artefact will be placed at the root of the output directory.
-	DownloadJobArtefact(ctx context.Context, jobName string, outputDirectory string, artefactManager *client.ArtefactManagerItem) error
+	DownloadJobArtefact(ctx context.Context, jobName string, outputDirectory string, artefactManager M) error
 	// DownloadJobArtefactWithTree downloads a specific artefact into the output directory.
 	// maintainTreeLocation specifies whether the artefact will be placed in a tree structure or if it will be flat.
-	DownloadJobArtefactWithTree(ctx context.Context, jobName string, maintainTreeLocation bool, outputDirectory string, artefactManager *client.ArtefactManagerItem) error
+	DownloadJobArtefactWithTree(ctx context.Context, jobName string, maintainTreeLocation bool, outputDirectory string, artefactManager M) error
 	// ListJobArtefacts lists all artefact managers associated with a particular job.
 	ListJobArtefacts(ctx context.Context, jobName string) (pagination.IPaginatorAndPageFetcher, error)
 	// DownloadAllJobArtefacts downloads all the artefacts produced for a particular job and puts them in an output directory as a flat list.
@@ -32,4 +34,32 @@ type IArtefactManager interface {
 	// DownloadAllJobArtefactsWithTree downloads all the artefacts produced for a particular job and puts them in an output directory.
 	// maintainTreeStructure specifies whether to keep the tree structure of the artefacts or not in the output directory.
 	DownloadAllJobArtefactsWithTree(ctx context.Context, jobName string, maintainTreeStructure bool, outputDirectory string) error
+}
+
+type LinkData interface {
+	comparable
+	GetName() string
+	GetHref() string
+}
+
+type Links[D LinkData] interface {
+	comparable
+	GetNextP() D
+	HasNext() bool
+}
+type Collection[D LinkData, L Links[D]] interface {
+	comparable
+	pagination.IStaticPage
+	GetLinksOk() (L, bool)
+}
+
+type Manager interface {
+	comparable
+	GetName() string
+	GetTitle() string
+	HasTitle() bool
+	GetHashOk() (*string, bool)
+	GetSizeOk() (*int64, bool)
+	GetExtraMetadata() map[string]string
+	HasExtraMetadata() bool
 }

--- a/utils/artefacts/interface.go
+++ b/utils/artefacts/interface.go
@@ -14,8 +14,8 @@ import (
 //go:generate mockgen -destination=../mocks/mock_$GOPACKAGE.go -package=mocks github.com/ARM-software/embedded-development-services-client-utils/utils/$GOPACKAGE IArtefactManager
 
 type IArtefactManager[
-	M Manager,
-	D LinkData,
+	M IManager,
+	D ILinkData,
 ] interface {
 	// DownloadJobArtefactFromLink downloads a specific artefact into the output directory from a particular link. The artefact will be placed at the root of the output directory.
 	DownloadJobArtefactFromLink(ctx context.Context, jobName string, outputDirectory string, artefactManagerItemLink D) error
@@ -36,24 +36,24 @@ type IArtefactManager[
 	DownloadAllJobArtefactsWithTree(ctx context.Context, jobName string, maintainTreeStructure bool, outputDirectory string) error
 }
 
-type LinkData interface {
+type ILinkData interface {
 	comparable
 	GetName() string
 	GetHref() string
 }
 
-type Links[D LinkData] interface {
+type ILinks[D ILinkData] interface {
 	comparable
 	GetNextP() D
 	HasNext() bool
 }
-type Collection[D LinkData, L Links[D]] interface {
+type ICollection[D ILinkData, L ILinks[D]] interface {
 	comparable
 	pagination.IStaticPage
 	GetLinksOk() (L, bool)
 }
 
-type Manager interface {
+type IManager interface {
 	comparable
 	GetName() string
 	GetTitle() string

--- a/utils/go.mod
+++ b/utils/go.mod
@@ -3,7 +3,7 @@ module github.com/ARM-software/embedded-development-services-client-utils/utils
 go 1.24
 
 require (
-	github.com/ARM-software/embedded-development-services-client/client v1.45.1
+	github.com/ARM-software/embedded-development-services-client/client v1.50.0
 	github.com/ARM-software/golang-utils/utils v1.89.0
 	github.com/go-faker/faker/v4 v4.6.0
 	github.com/go-logr/logr v1.4.2
@@ -11,7 +11,7 @@ require (
 	go.uber.org/atomic v1.11.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/mock v0.5.0
-	golang.org/x/sync v0.12.0
+	golang.org/x/sync v0.13.0
 )
 
 require (
@@ -76,7 +76,7 @@ require (
 	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 // indirect
 	golang.org/x/oauth2 v0.28.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
-	golang.org/x/text v0.23.0 // indirect
+	golang.org/x/text v0.24.0 // indirect
 	gopkg.in/toast.v1 v1.0.0-20180812000517-0a84660828b2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/utils/go.sum
+++ b/utils/go.sum
@@ -1,6 +1,8 @@
 bitbucket.org/creachadair/stringset v0.0.9/go.mod h1:t+4WcQ4+PXTa8aQdNKe40ZP6iwesoMFWAxPGd3UGjyY=
 github.com/ARM-software/embedded-development-services-client/client v1.45.1 h1:qB/nQm3RtVTLbPXI1BNH8RC8T0Bw06PJPY2geRKTpuw=
 github.com/ARM-software/embedded-development-services-client/client v1.45.1/go.mod h1:rQp94BDHwu/+Q27cwS8iObzaJW027hMTRpN5Jj+6Ddc=
+github.com/ARM-software/embedded-development-services-client/client v1.50.0 h1:6woKXzWh0XUlBGA2El5XhaW6FY9QxtvQ7Lhkjp+Yi8g=
+github.com/ARM-software/embedded-development-services-client/client v1.50.0/go.mod h1:I4n0SrcIgKKVbcJCBBwvANNz+Wjs/EZ9YwzIiFe4fsk=
 github.com/ARM-software/golang-utils/utils v1.89.0 h1:WyrZiTkzzHemZ4oqS/LbkjukDYyV7TCS1efAT9rmB4A=
 github.com/ARM-software/golang-utils/utils v1.89.0/go.mod h1:hbOnHpp3NKGQlSwI8YhIBLH5TrlPnFP3OE0HphMNqVI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -222,6 +224,8 @@ golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
 golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
+golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -257,6 +261,8 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
 golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
+golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
+golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/utils/go.sum
+++ b/utils/go.sum
@@ -1,6 +1,4 @@
 bitbucket.org/creachadair/stringset v0.0.9/go.mod h1:t+4WcQ4+PXTa8aQdNKe40ZP6iwesoMFWAxPGd3UGjyY=
-github.com/ARM-software/embedded-development-services-client/client v1.45.1 h1:qB/nQm3RtVTLbPXI1BNH8RC8T0Bw06PJPY2geRKTpuw=
-github.com/ARM-software/embedded-development-services-client/client v1.45.1/go.mod h1:rQp94BDHwu/+Q27cwS8iObzaJW027hMTRpN5Jj+6Ddc=
 github.com/ARM-software/embedded-development-services-client/client v1.50.0 h1:6woKXzWh0XUlBGA2El5XhaW6FY9QxtvQ7Lhkjp+Yi8g=
 github.com/ARM-software/embedded-development-services-client/client v1.50.0/go.mod h1:I4n0SrcIgKKVbcJCBBwvANNz+Wjs/EZ9YwzIiFe4fsk=
 github.com/ARM-software/golang-utils/utils v1.89.0 h1:WyrZiTkzzHemZ4oqS/LbkjukDYyV7TCS1efAT9rmB4A=
@@ -222,8 +220,6 @@ golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/oauth2 v0.28.0 h1:CrgCKl8PPAVtLnU3c+EDw6x11699EWlsDeWNWKdIOkc=
 golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
-golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
 golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -259,8 +255,6 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
-golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
 golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Proprietary
-->
### Description
This change removes explicit type dependency from artefacts utils structs and functions by using generics instead of the explicit types that were imported from "embedded-development-services-client".

The main issue was that the artefacts utils can only work with types defined in "embedded-development-services-client", even if another client package had the same type definitions, Go will still consider these types as incompatible because they come from different packages.

My first approach was relying on interfaces and adaptor types that converted specific client's types into types that implemented these interfaces, but this meant that every user SDK will need this boilerplate adaptor code to be able to work with the utils, which is avoided using this approach.

Another limitation that I faced, is that Go does not allow type manipulation in Generics (as in we can't take type T as an argument and transform it into pointer type *T), which meant that I had to work with either values only or pointer types, I chose to work with pointer types only to allow for type inference in the user SDK of the utils.
This means that the only extra change that is still required to make this work is to provide a static definition in the client generator for "HalCollectionLinks":
```
// GetNextP returns the Next field pointer if set, nil otherwise.
func (o *HalCollectionLinks) GetNextP() *HalLinkData {
	if o == nil || IsNil(o.Next) {
		return nil
	}
	return o.Next
}
```

As you can also see in the "artefacts_test.go" file, the only change that is required from the SDKs, is that if they need to instantiate IArtefactManager, it will need explicit types to be passed to it
```
// Example instantiation
IArtefactManager[*client.ArtefactManagerItem, *client.HalLinkData]
```
<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
