### PR TITLE
:sparkles: `errors` Improve the error that is returned when a response cannot be unmarshalled as JSON

### DIFF
--- a/changes/20250407100502.feature
+++ b/changes/20250407100502.feature
@@ -1,0 +1,1 @@
+:sparkles: `errors` Improve the error that is returned when a response cannot be unmarshalled as JSON

--- a/utils/api/api.go
+++ b/utils/api/api.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/ARM-software/embedded-development-services-client-utils/utils/errors"
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/parallelisation"
 	"github.com/ARM-software/golang-utils/utils/reflection"
 )
@@ -40,7 +41,7 @@ func CheckAPICallSuccess(ctx context.Context, errorContext string, resp *_http.R
 		if resp != nil {
 			statusCode = resp.StatusCode
 			errorDetails, subErr := errors.FetchAPIErrorDescriptionWithContext(ctx, resp)
-			if subErr != nil {
+			if commonerrors.Ignore(subErr, commonerrors.ErrMarshalling) != nil {
 				err = subErr
 				return
 			}

--- a/utils/api/api_test.go
+++ b/utils/api/api_test.go
@@ -58,6 +58,15 @@ func TestCheckAPICallSuccess(t *testing.T) {
 		assert.Equal(t, actualErr.Error(), expectedErr)
 	})
 
+	t.Run("api call not successful (no JSON response)", func(t *testing.T) {
+		errMessage := "response error"
+		parentCtx := context.Background()
+		resp := _http.Response{StatusCode: 403, Body: io.NopCloser(bytes.NewReader([]byte("<html><head><title>403 Forbidden</title></head></html>")))}
+		actualErr := CheckAPICallSuccess(parentCtx, errMessage, &resp, errors.New("403 Forbidden"))
+		expectedErr := "response error (403): <html><head><title>403 Forbidden</title></head></html>; 403 Forbidden"
+		assert.Equal(t, actualErr.Error(), expectedErr)
+	})
+
 	t.Run("no context error, api call successful", func(t *testing.T) {
 		errMessage := "no error"
 		parentCtx := context.Background()

--- a/utils/errors/errors.go
+++ b/utils/errors/errors.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/ARM-software/embedded-development-services-client/client"
+	"github.com/ARM-software/golang-utils/utils/commonerrors"
 	"github.com/ARM-software/golang-utils/utils/parallelisation"
 	"github.com/ARM-software/golang-utils/utils/reflection"
 	"github.com/ARM-software/golang-utils/utils/safeio"
@@ -51,6 +52,7 @@ func FetchAPIErrorDescriptionWithContext(ctx context.Context, resp *_http.Respon
 	}
 	if err != nil {
 		message = string(bytes)
+		err = commonerrors.WrapError(commonerrors.ErrMarshalling, err, "error occurred when unmarshalling response")
 		return
 	}
 	apiErrorMessage := strings.Builder{}

--- a/utils/errors/errors_test.go
+++ b/utils/errors/errors_test.go
@@ -45,6 +45,13 @@ func TestFetchAPIErrorDescription(t *testing.T) {
 		expectedMessage := ""
 		assert.Equal(t, expectedMessage, actualMessage)
 	})
+
+	t.Run("error response is not JSON", func(t *testing.T) {
+		resp := _http.Response{Body: io.NopCloser(bytes.NewReader([]byte("<html><head><title>403 Forbidden</title></head></html>")))}
+		actualMessage := FetchAPIErrorDescription(&resp)
+		expectedMessage := "<html><head><title>403 Forbidden</title></head></html>"
+		assert.Equal(t, expectedMessage, actualMessage)
+	})
 }
 
 func TestFetchAPIErrorDescriptionInterrupt(t *testing.T) {


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Proprietary
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Improve the error that is returned when a response cannot be unmarshalled as JSON

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
