### PR TITLE
⚙️ Add a check in CallAndCheckSuccess for response unmarshalling issues

### DIFF
--- a/changes/20250423114015.bugfix
+++ b/changes/20250423114015.bugfix
@@ -1,0 +1,1 @@
+:gear: Add a check in CallAndCheckSuccess for response unmarshalling issues

--- a/utils/api/api.go
+++ b/utils/api/api.go
@@ -62,7 +62,7 @@ func CheckAPICallSuccess(ctx context.Context, errorContext string, resp *_http.R
 // CallAndCheckSuccess is a wrapper for making an API call and then checking success with `CheckAPICallSuccess`
 // errorContext corresponds to the description of what led to the error if error there is e.g. `Failed adding a user`.
 // apiCallFunc corresponds to a generic function that will be called to make the API call
-func CallAndCheckSuccess[T any](ctx context.Context, errorContext string, apiCallFunc func(ctx context.Context) (T, *_http.Response, error)) (result T, err error) {
+func CallAndCheckSuccess[T any](ctx context.Context, errorContext string, apiCallFunc func(ctx context.Context) (*T, *_http.Response, error)) (result *T, err error) {
 	if err = parallelisation.DetermineContextError(ctx); err != nil {
 		return
 	}
@@ -74,6 +74,13 @@ func CallAndCheckSuccess[T any](ctx context.Context, errorContext string, apiCal
 
 	if err = CheckAPICallSuccess(ctx, errorContext, resp, apiErr); err != nil {
 		return
+	}
+
+	if result != nil {
+		if reflection.IsEmpty(result) {
+			err = commonerrors.New(commonerrors.ErrMarshalling, "unmarshalled response is empty")
+			return
+		}
 	}
 
 	return

--- a/utils/api/api_test.go
+++ b/utils/api/api_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ARM-software/golang-utils/utils/commonerrors"
+	"github.com/ARM-software/golang-utils/utils/commonerrors/errortest"
 )
 
 func TestIsAPICallSuccessful(t *testing.T) {
@@ -46,7 +47,8 @@ func TestCheckAPICallSuccess(t *testing.T) {
 		cancelCtx()
 		respBody := _http.Response{Body: io.NopCloser(bytes.NewReader(nil))}
 		actualErr := CheckAPICallSuccess(ctx, errMessage, &respBody, errors.New(errMessage))
-		assert.True(t, commonerrors.Any(actualErr, commonerrors.ErrCancelled))
+		errortest.AssertError(t, actualErr, commonerrors.ErrCancelled)
+
 	})
 
 	t.Run("api call not successful", func(t *testing.T) {
@@ -86,7 +88,7 @@ func TestCallAndCheckSuccess(t *testing.T) {
 			func(ctx context.Context) (*struct{}, *_http.Response, error) {
 				return nil, &_http.Response{Body: io.NopCloser(bytes.NewReader(nil))}, errors.New(errMessage)
 			})
-		assert.True(t, commonerrors.Any(actualErr, commonerrors.ErrCancelled))
+		errortest.AssertError(t, actualErr, commonerrors.ErrCancelled)
 	})
 
 	t.Run("api call not successful", func(t *testing.T) {
@@ -118,6 +120,6 @@ func TestCallAndCheckSuccess(t *testing.T) {
 			func(ctx context.Context) (*struct{}, *_http.Response, error) {
 				return &struct{}{}, &_http.Response{StatusCode: 200}, errors.New(errMessage)
 			})
-		assert.True(t, commonerrors.Any(err, commonerrors.ErrMarshalling))
+		errortest.AssertError(t, err, commonerrors.ErrMarshalling)
 	})
 }

--- a/utils/api/api_test.go
+++ b/utils/api/api_test.go
@@ -110,4 +110,14 @@ func TestCallAndCheckSuccess(t *testing.T) {
 			})
 		assert.NoError(t, err)
 	})
+
+	t.Run("api call successful, empty response", func(t *testing.T) {
+		errMessage := "response error"
+		parentCtx := context.Background()
+		_, err := CallAndCheckSuccess(parentCtx, errMessage,
+			func(ctx context.Context) (*struct{}, *_http.Response, error) {
+				return &struct{}{}, &_http.Response{StatusCode: 200}, errors.New(errMessage)
+			})
+		assert.True(t, commonerrors.Any(err, commonerrors.ErrMarshalling))
+	})
 }


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Proprietary
-->
### Description
This changes add an extra check CallAndCheckSuccess to detect empty unmarshalled responses.
The restriction in the return type [T] to be a pointer allows us to optimize calling reflection.IsEmpty only when that pointer is not nil


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [X]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
