### PR TITLE
📝 Remove code climate references

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,21 +77,6 @@ jobs:
           version: latest
           working-directory: ${{ matrix.go-module }}
           args: "--verbose --print-issued-lines --print-linter-name --out-${NO_FUTURE}format colored-line-number --timeout 300s --max-issues-per-linter 0 --max-same-issues 0"
-# FIXME Send coverage to code climate
-#
-#      - if: ${{ startsWith(matrix.os, 'ubuntu') }}
-#        name: Test [${{ matrix.go-module }} on ${{ matrix.os }}] & Publish Code Coverage
-#        uses: paambaati/codeclimate-action@v2.7.5
-#        env:
-#          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-#        with:
-#          debug: true
-#          workingDirectory: ${{ matrix.go-module }}
-#          coverageCommand: go test -race -cover -v -coverprofile ${{ matrix.go-module }}_coverage.out ./...
-#          prefix: github.com/ARM-software/${{ github.event.repository.name }}/${{ matrix.go-module }}
-#          coverageLocations:
-#            "${{github.workspace}}/${{ matrix.go-module }}/${{ matrix.go-module }}_coverage.out:gocov"
-#      - if: ${{ startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'macOS') }}
       - name: Test ${{ matrix.go-module }} on ${{ matrix.os }}
         run: go test -race -cover -v ./...
         working-directory: ${{ matrix.go-module }}

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -67,6 +67,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -101,5 +105,5 @@
     }
   ],
   "results": {},
-  "generated_at": "2025-04-28T23:41:43Z"
+  "generated_at": "2025-06-12T11:22:54Z"
 }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -49,17 +49,6 @@ If you want to manually run all pre-commit hooks on a repository without creatin
 
 To run individual hooks use `pre-commit run <hook_id>`.
 
-## Code Climate
-
-Code Climate is integrated with our GitHub flow. Failing the configured rules will yield a pull request not mergeable.
-
-If you prefer to view the Code Climate report on your machine, prior to sending a pull request, you can use the [cli provided by Code Climate](https://docs.codeclimate.com/docs/command-line-interface).
-
-Plugins for various tools are also available:
-  - [Atom](https://docs.codeclimate.com/docs/code-climate-atom-package)
-  - [PyCharm](https://plugins.jetbrains.com/plugin/13306-code-cleaner-with-code-climate-cli)
-  - [Vim](https://docs.codeclimate.com/docs/vim-plugin)
-
 # Dependency upgrades
 
 For dependency upgrades, dependabot is relied upon and news files are auto-generated in order to document such change.

--- a/changes/20250612122250.misc
+++ b/changes/20250612122250.misc
@@ -1,0 +1,1 @@
+:memo: Remove code climate references


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Proprietary
-->
### Description

This removes code climate references in files as we have now migrated to Qlty Cloud.

_NB: The work to integrate Qlty Cloud changes will be a separate PR as it's dependent on the existence of a repo/organisation level secret for authentication with Qlty._

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [X]  Additional tests are not required for this change (e.g. documentation update).
